### PR TITLE
Attendees and Schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,39 @@
 # Potassco ASP Workshop 2025
 
-This repository for organizing ASP workshop taking place in May 2025, Potsdam.
+The repository for organizing the ASP workshop taking place May 2025 in Potsdam.
 
-## When?
+## Where and when?
 
-2 consecutive days between May 5-9th.
+Tuesday, May 6 and Wednesday, May 7.
 
-Tuesday Wednesday would be convenient for Pedro, as he would prefer to fly on Monday.
+### Tuesday
 
-## Where?
+| Time | Room | Activity |
+| -- | -- | -- |
+| 8:40 – 9:20 | 0.10 | Arrival |
+| 9:20 – 10:00 | 0.10 | First Session |
+| 10:00 – 11:20 | 0.08 | Session Block |
+| 11:35 – 12:45 | Mensa | Lunch |
+| 13:00 – 16:45 | Lab | Session Block |
+| 18:00 – 19:30 | Potsdam | Dinner |
 
-Can we get a nice room in House 70 for two consecutive days?
+### Wednesday
+
+| Time | Room | Activity |
+| -- | -- | -- |
+| 8:40 – 9:20 | 0.11 | Arrival |
+| 9:20 – 11:20 | 0.11 | Session Block |
+| 11:30 – 12:45 | Mensa | Lunch |
+| 13:00 – 16:15 | Lab | Session Block |
+| 17:30 – 18:00 | Potsdam | Beer Garden |
+
+### Arrival Train Connections
+
+| Route | Berlin Hbf | Potsdam Hbf | Golm |
+| -- | -- | -- | -- |
+| RB 23 | 7:50 | 8:18 | 8:29 |
+| RB 21 | - | 8:36 | 8:45 |
+| RB 22 | - | 8:48 | 8:58 |
 
 ## Who will talk? What will be the format?
 
@@ -26,19 +49,34 @@ Themes, and discussions, demos and talks around them
 ## Who could/will attend?
 
 ### Internal
+* Torsten
+* Susana
+* Nico
+* Tobias
+* Amadé
+* kep
+* Phillipp W.
+* Henry
+* Klaus
+* Javier
+* Arvid
+* Roland
+* Benny
 
 ### External
+#### Theoretical side
+* Jesse Heyninck
+* Brais Muniz
+* Pedro Cabalar
+* Francois Olivier
+* Ruolin Wang - already going to be here
+* Xianni Wang - already going to be here
+* David Pearce - awaiting confirmation
+* Martin Dieguez - tentative
+* Jiri Svancara - follow-up request
+* ~~Jorge Fandinno~~
 
-Brais Muniz
-David Pearce
-Francois Olivier
-Jesse Heyninck
-Jiri Svancara
-Jochen Reutelshoefer
-Jorge Fandinno
-Konstantin Herud
-Martin Dieguez
-Martin Gebser (et al)
-Pedro Cabalar
-Ruolin Wang
-Xianni Wang
+#### Applied side
+* Jochen Reutelshoefer
+* Konstantin Herud
+* Martin Gebser (et al)


### PR DESCRIPTION
We've updated the list of probable attendees. I have also put together a tentative schedule for each day—of course, the session blocks can be broken up more concretely once we determine the topics for discussion.

The downstairs rooms listed in the schedules have already been reserved through Sebastian.

For our planning purposes (i.e. making a dinner reservation), it looks like the maximum number of participants will be around 22. Assuming that not everyone would be able to make it for dinner, we could look to place a reservation for around 18 people—better to overestimate than to underestimate.

I propose finishing up a bit earlier on Wednesday, to allow for attendees who are leaving Thursday to have ample time to get back to their hotels so they can pack and get enough rest.

Thoughts and feedback are always welcome.